### PR TITLE
Fixed PassManager.h include issue in LEGTargetMachine.cpp

### DIFF
--- a/lib/Target/LEG/LEGTargetMachine.cpp
+++ b/lib/Target/LEG/LEGTargetMachine.cpp
@@ -19,7 +19,7 @@
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 #include "llvm/IR/Module.h"
-#include "llvm/PassManager.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Support/TargetRegistry.h"
 
 using namespace llvm;


### PR DESCRIPTION
Build was failing as PassManager.h was not included in LEGTargetMachine.cpp properly.
