### PR TITLE
Fixed Compile error

### DIFF
--- a/include/llvm/IR/ValueMap.h
+++ b/include/llvm/IR/ValueMap.h
@@ -99,7 +99,7 @@ public:
   explicit ValueMap(const ExtraData &Data, unsigned NumInitBuckets = 64)
       : Map(NumInitBuckets), Data(Data) {}
 
-  bool hasMD() const { return MDMap; }
+  bool hasMD() const { return static_cast<bool>(MDMap); }
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);


### PR DESCRIPTION
Dear Respectful frasercrmck,

Thanks for your contributing a good example of making own LLVM backend.
While I am building your project with gcc-8 or later, I found a small compile error.
The detail that I faced is the same as following.
https://github.com/microsoft/DirectXShaderCompiler/issues/1692

It was about not being able to convert unique_ptr to bool type implicitly.
So it was needed to be modified to convert explicitly, which was I did.

As is
bool hasMD() const { return MDMap; }
To be
bool hasMD() const { return static_cast<bool>(MDMap); }

(Actually, I have not yet verified if certain side effects exist when using gcc 4.9.)

Best Regards, ^^